### PR TITLE
Fixes numberOnly behaviour on mobile devices

### DIFF
--- a/src/lib/components/OtpItem.svelte
+++ b/src/lib/components/OtpItem.svelte
@@ -11,6 +11,7 @@
 	export let placeholder: string;
 
 	let key: string;
+	let inputType: string = num ? "number" : "text"
 
 	function shiftFocus(key: string) {
 		if (
@@ -95,6 +96,7 @@
 	{style}
 	{value}
 	{placeholder}
+	type="{inputType}"
 />
 
 <style>


### PR DESCRIPTION
### Fixes
Mobile device behaviour when `numberOnly` prop is `true`.
Now:
 - The numpad will show instead of a full keyboard.
 - When the user presses a number, the cursor moves to the next `OtpItem` input just like it does on desktop.